### PR TITLE
Fix generated source causing compilation errors on some platforms

### DIFF
--- a/src/Podimo.ConstEmbed/ConstEmbedGenerator.cs
+++ b/src/Podimo.ConstEmbed/ConstEmbedGenerator.cs
@@ -23,7 +23,7 @@ public class ConstEmbedGenerator : IIncrementalGenerator
                     var @class = pair.Right.GetAdditionalFileMetadata(pair.Left, "ConstEmbed");
                     return (Class: @class, File: pair.Left);
                 })
-                .Where(static pair => pair.Class is not null);
+                .Where(static pair => !string.IsNullOrEmpty(pair.Class));
 
         var combined = additionalFiles.Combine(globalOptions);
 


### PR DESCRIPTION
On some dotnet SDKs and platforms, it's possible for an incorrect empty string to be returned by `AnalyzerConfigOptions.TryGetValue()` instead of a null when the attribute was not found

While it does look to be an upstream bug, a missing class name is also not an acceptable value to begin with as it fails the build. It would be reasonable for us to check for and skip entries expressing empty class names rather than nulls for anyone on dotnet SDKs with with this bug

The SDK/Platform known to be expressing this bug is 7.0.410, Linux x64 This is the current latest running on GitHub Actions for .NET 7.x

As for replicating the bug, it was encountered by adding a resource for the banned API analyzer in the solutions root's `Directory.Build.props`:

```xml
<ItemGroup>
  <GlobalPackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4" />
  <AdditionalFiles Include="$(MSBuildThisFileDirectory)/.meta/BannedSymbols.txt" />
</ItemGroup>
```